### PR TITLE
ci: use the correct commit message variable

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -47,7 +47,7 @@ jobs:
           done
 
           commit_msg=$(git diff --name-only -- releases | jq -Rrs '"update: \(gsub("\n"; ","))"')
-          git commit -m "$releases_commit_msg" releases || :
+          git commit -m "$commit_msg" releases || :
 
       - run: git push
 


### PR DESCRIPTION
Allows CI to work again, see https://github.com/NicoElbers/zig-flake/actions/runs/21287060367

Closes #4